### PR TITLE
Multiple random seeds

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "lodash": "^4.17.10",
     "milligram": "^1.3.0",
     "morgan": "^1.9.0",
-    "pug": "^2.0.0-rc.4"
+    "pug": "^2.0.0-rc.4",
+    "random-seed": "^0.3.0"
   },
   "devDependencies": {
     "@types/body-parser": "1.16.8",

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -3,11 +3,24 @@ textarea {
     min-height: 400px;
 }
 
-canvas {
-    border: 1px solid rgba(0, 0, 0, 0.15);
-    box-shadow: 1px 2px 1px rgba(0, 0, 0, 0.15);
+#webgl {
     min-height: 400px;
-    width: 100%;
+    width: 400px;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+}
+
+#webgl > div {
+  cursor: pointer;
+  transition: all ease 0.1s;
+  margin: 0 20px 20px 0;
+}
+
+#webgl > div:hover {
+  transform: scale(1.05);
 }
 
 pre {
@@ -20,4 +33,9 @@ pre > code {
 
 #source {
     min-height: 400px;
+}
+
+.column.fixed {
+    width: auto;
+    flex: 0;
 }

--- a/public/views/index.pug
+++ b/public/views/index.pug
@@ -14,16 +14,23 @@ html
       hr
 
       .row
-        .column.column-50
+        .column
           h2 Calder Code
-          form(method='POST' action='/')
+          form#state(method='POST' action='/')
             #source
             textarea(name='source')= source
+            input#seed0(type='hidden' name='seed0' value=seeds[0])
+            input#seed1(type='hidden' name='seed1' value=seeds[1])
+            input#seed2(type='hidden' name='seed2' value=seeds[2])
+            input#seed3(type='hidden' name='seed3' value=seeds[3])
+            input#focused(type='hidden' name='focused' value=focused)
             input(type='submit' name='Run')
 
-        .column.column-50
+        .column.fixed
           h2 Compiled WebGL
           div#webgl
+          div#toolbar
+            button#shuffle Shuffle random seeds
 
       .row
         pre

--- a/samples/tree.js
+++ b/samples/tree.js
@@ -1,0 +1,92 @@
+/**
+ * Write your Calder code here
+ */
+
+const light1 = {
+    lightPosition: [10, 10, 10],
+    lightColor: [0.3, 0.3, 0.3],
+    lightIntensity: 256
+};
+const light2 = {
+    lightPosition: [700, 500, 50],
+    lightColor: [0.3, 0.3, 0.3],
+    lightIntensity: 100
+};
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Step 1: create geometry
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Add lights to the renderer
+renderer.addLight(light1);
+renderer.addLight(light2);
+
+// Setup leaf
+const leafColor = RGBColor.fromRGB(204, 255, 204);
+const workingLeafSphere = Shape.sphere(leafColor);
+const leafSphere = workingLeafSphere.bake();
+
+// Setup branch
+const branchColor = RGBColor.fromRGB(102, 76.5, 76.5);
+const workingBranchShape = Shape.cylinder(branchColor);
+const branchShape = workingBranchShape.bake();
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Step 2: create armature
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+const bone = Armature.define((root) => {
+    root.createPoint('base', { x: 0, y: 0, z: 0 });
+    root.createPoint('mid', { x: 0, y: 0.5, z: 0 });
+    root.createPoint('tip', { x: 0, y: 1, z: 0 });
+});
+
+const treeGen = Armature.generator();
+const tree = treeGen
+    .define('branch', 1, (root) => {
+        const node = bone();
+        node.point('base').stickTo(root);
+        const theta = Math.random() * 45;
+        const phi = Math.random() * 360;
+        node.setRotation(Matrix.fromQuat4(Quaternion.fromEuler(theta, phi, 0)));
+        node.setScale(Matrix.fromScaling({ x: 0.8, y: 0.8, z: 0.8 })); // Shrink a bit
+
+        const trunk = node.point('mid').attach(branchShape);
+        trunk.setScale(Matrix.fromScaling({ x: 0.2, y: 1, z: 0.2 }));
+
+        // branching factor of 2
+        treeGen.addDetail({ component: 'branchOrLeaf', at: node.point('tip') });
+        treeGen.addDetail({ component: 'branchOrLeaf', at: node.point('tip') });
+    })
+    .define('branchOrLeaf', 1, (root) => {
+        treeGen.addDetail({ component: 'leaf', at: root });
+    })
+    .define('branchOrLeaf', 4, (root) => {
+        treeGen.addDetail({ component: 'branch', at: root });
+    })
+    .define('leaf', 1, (root) => {
+        const leaf = root.attach(leafSphere);
+        const scale = Math.random() * 0.5 + 0.5;
+        leaf.setScale(Matrix.fromScaling({ x: scale, y: scale, z: scale }));
+    })
+    .generate({ start: 'branch', depth: 15 });
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Step 3: set up renderer
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+document.body.appendChild(renderer.stage);
+
+renderer.camera.moveTo({ x: 0, y: 0, z: 8 });
+renderer.camera.lookAt({ x: 2, y: 2, z: -4 });
+
+// Draw the armature
+const draw = () => {
+    return {
+        objects: [tree],
+        debugParams: { drawAxes: true, drawArmatureBones: false }
+    };
+};
+
+// Apply the constraints each frame.
+renderer.eachFrame(draw);

--- a/src/frontend/client.ts
+++ b/src/frontend/client.ts
@@ -1,4 +1,6 @@
 import * as calder from 'calder-gl';
+const randomSeed = require('random-seed');
+import { range } from 'lodash';
 
 for (const key in calder) {
     (<any>window)[key] = calder[key];
@@ -19,9 +21,14 @@ if (webglElement === null) {
     throw new Error('Could not find webgl element');
 }
 
+const shuffleBtn = <HTMLButtonElement> document.getElementById('shuffle');
+const form = <HTMLFormElement> document.getElementById('state');
+const seedElements = range(4).map((i) => <HTMLInputElement> document.getElementById(`seed${i}`));
+const focusedElement = <HTMLInputElement> document.getElementById('focused');
+
 const oldLog = console.log;
 console.log = function() {
-    logElement.innerText += Array.prototype.map.call(arguments, (a: any) => `${a}`).join(', ');
+    logElement.innerText += Array.prototype.map.call(arguments, (a: any) => `${a}`).join(', ') + '\n';
     oldLog.apply(console, arguments);
 };
 
@@ -33,7 +40,34 @@ const code = codeElement.innerText;
 
 const setup = new Function('renderer', code);
 
-const renderer = new calder.Renderer(800, 600, 10);
-setup(renderer);
+const oldRandom = Math.random;
+const render = (seed, size, handler) => {
+    const generator = randomSeed.create();
+    generator.seed(seed);
+    Math.random = () => generator.random();
 
-webglElement.appendChild(renderer.stage);
+    const renderer = new calder.Renderer(size, size, 10);
+    setup(renderer);
+
+    webglElement.appendChild(renderer.stage);
+    renderer.stage.addEventListener('click', handler);
+};
+
+const seeds = seedElements.map((e) => parseFloat(e.value));
+const focused = parseInt(focusedElement.value);
+if (focused >= 0 && focused < 4) {
+    render(seeds[focused], 400, () => {
+        focusedElement.value = '-1';
+        form.submit();
+    });
+} else {
+    seeds.forEach((seed, i) => render(seed, 150, () => {
+        focusedElement.value = `${i}`;
+        form.submit();
+    }));
+}
+
+shuffleBtn.addEventListener('click', () => {
+    seedElements.map((e) => e.value = oldRandom() * 10000);
+    form.submit();
+});

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -3,6 +3,7 @@ import { BaseRoute } from "./base_route";
 import { transform } from 'babel-core';
 import  * as fs from 'fs';
 import * as path from "path";
+import { range } from 'lodash';
 
 /**
  * Concrete class for the `/` route.
@@ -11,7 +12,7 @@ import * as path from "path";
  */
 export class IndexRoute extends BaseRoute {
     private static defaultSource: string =
-        '' + fs.readFileSync(path.join(__dirname, '../../samples/bone.js'));
+        '' + fs.readFileSync(path.join(__dirname, '../../samples/tree.js'));
 
     /**
      * Create the routes.
@@ -51,12 +52,14 @@ export class IndexRoute extends BaseRoute {
     public renderGL(req: Request, res: Response) {
         console.log(req.body.source);
         const source = req.body.source || IndexRoute.defaultSource;
+        const focused = req.body.focused || 0;
+        const seeds = range(4).map((i: number) => req.body[`seed${i}`] || Math.random() * 100000);
 
         // Transpile the code into ES5 JavaScript
         const { code } = transform(source, { sourceType: 'script' });
 
         // Pass in an object to the view to update content
-        const options: Object = { source, code };
+        const options: Object = { source, code, seeds, focused };
 
         // Render the index page
         this.render(req, res, "index", options);

--- a/yarn.lock
+++ b/yarn.lock
@@ -799,7 +799,7 @@ cache-base@^1.0.1:
 
 calder-gl@calder-gl/calder#master:
   version "0.0.0"
-  resolved "https://codeload.github.com/calder-gl/calder/tar.gz/1c97c5bf47476e01b1c3d55d71fb8df17097b729"
+  resolved "https://codeload.github.com/calder-gl/calder/tar.gz/6dae8d9fd073fb5e1c2ff72991da07d53eb0d886"
   dependencies:
     gl-matrix "^2.5.1"
     lodash "^4.17.10"
@@ -3501,6 +3501,10 @@ registry-url@^3.0.3:
   dependencies:
     rc "^1.0.1"
 
+regl@^1.3.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/regl/-/regl-1.3.6.tgz#d69967c577208ce69c2de7989c6188d565b242a0"
+
 regl@regl-project/regl:
   version "1.3.6"
   resolved "https://codeload.github.com/regl-project/regl/tar.gz/3dc66c5d52771e79562bbf28818250329c8f422e"
@@ -4133,7 +4137,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.6.1, typescript@^2.6.2:
+typescript@^2.6.1:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
+
+typescript@^2.6.2:
   version "2.9.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.1.tgz#fdb19d2c67a15d11995fd15640e373e09ab09961"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2391,6 +2391,10 @@ json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
 
+json-stringify-safe@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
+
 json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
@@ -3369,6 +3373,12 @@ querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
 
+random-seed@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/random-seed/-/random-seed-0.3.0.tgz#d945f2e1f38f49e8d58913431b8bf6bb937556cd"
+  dependencies:
+    json-stringify-safe "^5.0.1"
+
 randomatic@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-3.0.0.tgz#d35490030eb4f7578de292ce6dfb04a91a128923"
@@ -3500,10 +3510,6 @@ registry-url@^3.0.3:
   resolved "https://registry.yarnpkg.com/registry-url/-/registry-url-3.1.0.tgz#3d4ef870f73dde1d77f0cf9a381432444e174942"
   dependencies:
     rc "^1.0.1"
-
-regl@^1.3.1:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/regl/-/regl-1.3.6.tgz#d69967c577208ce69c2de7989c6188d565b242a0"
 
 regl@regl-project/regl:
   version "1.3.6"


### PR DESCRIPTION
Initial view:
![screen shot 2018-06-14 at 10 19 39 pm](https://user-images.githubusercontent.com/5315059/41447036-30cfb2a4-7021-11e8-88b2-59add50c8f4b.png)

Multi seed view
![screen shot 2018-06-14 at 10 19 35 pm](https://user-images.githubusercontent.com/5315059/41447038-32cffd52-7021-11e8-9c48-bb8b17bf5e01.png)

Click on the 3D view to toggle between the two. In multi-seed view, clicking on an individual seed maximizes it.

TODO
- Do this client-side so the whole page doesn't need to refresh each time
- Add a proper random number API to Calder so that we don't need to overwrite `Math.random` (if there is any dynamic randomness, this will break rn)