### PR TITLE
Update calder, update examples, add lodash to frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,12 @@ yarn server
 ```bash
 open http://localhost:3000
 ```
+
+## Updating Calder
+To use a newer version of Calder in this repo, run the following:
+
+```bash
+yarn upgrade
+```
+
+This will change the commit for `calder#master` in `yarn.lock`, which you can then commit.

--- a/samples/basic.js
+++ b/samples/basic.js
@@ -10,12 +10,12 @@ const bone = Armature.define((root) => {
 
 const node = bone();
 
-const light1 = new Light({
+const light = Light.create({
     position: { x: 10, y: 10, z: 10 },
     color: RGBColor.fromHex('#FFFFFF'),
-    intensity: 256
+    strength: 300
 });
-renderer.addLight(light1);
+renderer.addLight(light);
 
 renderer.camera.moveTo({ x: 0, y: 0, z: 8 });
 renderer.camera.lookAt({ x: 2, y: 2, z: -4 });

--- a/samples/snake.js
+++ b/samples/snake.js
@@ -1,0 +1,87 @@
+// Snake
+
+const bone = Armature.define((root) => {
+    root.createPoint('base', { x: 0, y: 0, z: 0 });
+    root.createPoint('mid', { x: 0, y: 0.5, z: 0 });
+    root.createPoint('tip', { x: 0, y: 1, z: 0 });
+    root.createPoint('handle', { x: 1, y: 0, z: 0});
+});
+
+const segmentBone = Armature.define((root) => {
+    root.createPoint('base', { x: 0, y: 0, z: 0 });
+    root.createPoint('mid', { x: 0, y: 0.5, z: 0 });
+    root.createPoint('tip', { x: 0, y: 1, z: 0 });
+    root.createPoint('handle', {x: 0, y: 0, z: 1});
+});
+
+const snakeMaterial = Material.create({
+    color: RGBColor.fromHex('#90C3D4')
+        .mix(RGBColor.fromHex('#71E366'), Math.random()),
+    shininess: 256
+});
+const segmentShape = Shape.cylinder(snakeMaterial).bake();
+const headShape = Shape.sphere(snakeMaterial).bake();
+const eyeShape = Shape.sphere(Material.create({
+    color: RGBColor.fromHex('#FFFFFF'),
+    shininess: 256
+})).bake();
+const pupilShape = Shape.sphere(Material.create({
+    color: RGBColor.fromHex('#000000'),
+    shininess: 0
+})).bake();
+
+const snake = Armature.generator();
+snake.define('base', (spawn) => {
+    const base = bone();
+    base.point('base').stickTo(spawn);
+    base.hold(base.point('handle')).rotate(90);
+    
+    snake.addDetail({component: 'segment or head', at: base.point('base')});
+    snake.addDetail({component: 'tail', at: base.point('base')});
+});
+snake.define('tail', (spawn) => {
+   let point = spawn;
+   range(4).forEach(() => {
+       const tail = bone();
+       tail.point('tip').stickTo(point);
+       tail.scale(0.7);
+       tail.point('mid').attach(segmentShape).scale({x: 0.5, y: 1.2, z: 0.3});
+       point = tail.point('base');
+   });
+});
+snake.defineWeighted('segment or head', 1, (spawn) => {
+    const head = bone();
+    head.createPoint('eye1', {x: 0.4, y: 0.5, z: 0.4});
+    head.createPoint('eye2', {x: -0.4, y: 0.5, z: 0.4});
+    head.createPoint('pupil1', {x: 0.45, y: 0.65, z: 0.4});
+    head.createPoint('pupil2', {x: -0.45, y: 0.65, z: 0.4});
+    head.point('base').stickTo(spawn);
+    head.point('mid').attach(headShape).scale({x: 0.7, y: 0.8, z: 0.4});
+    head.point('eye1').attach(eyeShape).scale(0.2);
+    head.point('eye2').attach(eyeShape).scale(0.2);
+    head.point('pupil1').attach(pupilShape).scale(0.1);
+    head.point('pupil2').attach(pupilShape).scale(0.1);
+});
+snake.defineWeighted('segment or head', 3, (spawn) => {
+    const segment = segmentBone();
+    segment.point('base').stickTo(spawn);
+    segment.point('mid').attach(segmentShape).scale({x: 0.5, y: 1.2, z: 0.3});
+    segment.hold(segment.point('handle')).rotate(Math.random()*90 - 45).release();
+    snake.addDetail({component: 'segment or head', at: segment.point('tip')});
+});
+
+const node = snake.generate({ start: 'base', depth: 20});
+node.hold({x: 0, y: 0, z: 0}).hold({x: 0, y: 1, z: 0}).rotate(-120).release();
+
+const light = Light.create({
+    position: { x: 15, y: 15, z: 15 },
+    color: RGBColor.fromHex('#FFFFFF'),
+    strength: 400
+});
+renderer.addLight(light);
+
+renderer.camera.moveTo({ x: 8, y: 20, z: 25 });
+renderer.camera.lookAt({ x: 2, y: 2, z: -4 });
+
+renderer.draw([node], {drawAxes: true, drawArmatureBones: false});
+

--- a/samples/tree.js
+++ b/samples/tree.js
@@ -1,81 +1,69 @@
-/**
- * Write your Calder code here
- */
+// Tree
 
-const light1 = new Light({
+const light = Light.create({
     position: { x: 10, y: 10, z: 10 },
     color: RGBColor.fromHex('#FFFFFF'),
-    intensity: 256
+    strength: 300
 });
-const light2 = new Light({
-    position: { x: 700, y: 500, z: 50 },
-    color: RGBColor.fromHex('#FFFFFF'),
-    intensity: 100
-});
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
-// Step 1: create geometry
-///////////////////////////////////////////////////////////////////////////////////////////////////
 
 // Add lights to the renderer
-renderer.addLight(light1);
-renderer.addLight(light2);
+renderer.addLight(light);
 
 // Setup leaf
 const leafColor = RGBColor.fromRGB(204, 255, 204);
-const workingLeafSphere = Shape.sphere(leafColor);
+const workingLeafSphere = Shape.sphere(Material.create({
+    color: leafColor,
+    shininess: 20
+}));
 const leafSphere = workingLeafSphere.bake();
 
 // Setup branch
 const branchColor = RGBColor.fromRGB(102, 76.5, 76.5);
-const workingBranchShape = Shape.cylinder(branchColor);
+const workingBranchShape = Shape.cylinder(Material.create({
+    color: branchColor,
+    shininess: 1
+}));
 const branchShape = workingBranchShape.bake();
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
-// Step 2: create armature
-///////////////////////////////////////////////////////////////////////////////////////////////////
 
 const bone = Armature.define((root) => {
     root.createPoint('base', { x: 0, y: 0, z: 0 });
     root.createPoint('mid', { x: 0, y: 0.5, z: 0 });
     root.createPoint('tip', { x: 0, y: 1, z: 0 });
+    root.createPoint('handle', { x: 1, y: 0, z: 0 });
 });
 
 const treeGen = Armature.generator();
-const tree = treeGen
-    .define('branch', 1, (root) => {
-        const node = bone();
-        node.point('base').stickTo(root);
-        const theta = Math.random() * 45;
-        const phi = Math.random() * 360;
-        node.setRotation(Matrix.fromQuat4(Quaternion.fromEuler(theta, phi, 0)));
-        node.setScale(Matrix.fromScaling({ x: 0.8, y: 0.8, z: 0.8 })); // Shrink a bit
+treeGen.define('branch', (root) => {
+    const node = bone();
+    node.point('base').stickTo(root);
+    node.hold(node.point('tip')).rotate(Math.random() * 360).release();
+    node.hold(node.point('handle')).rotate(Math.random() * 45).release();
+    node.scale(0.8); // Shrink a bit
 
-        const trunk = node.point('mid').attach(branchShape);
-        trunk.setScale(Matrix.fromScaling({ x: 0.2, y: 1, z: 0.2 }));
+    const trunk = node.point('mid').attach(branchShape);
+    trunk.scale({ x: 0.2, y: 1, z: 0.2 });
 
-        // branching factor of 2
-        treeGen.addDetail({ component: 'branchOrLeaf', at: node.point('tip') });
-        treeGen.addDetail({ component: 'branchOrLeaf', at: node.point('tip') });
-    })
-    .define('branchOrLeaf', 1, (root) => {
-        treeGen.addDetail({ component: 'leaf', at: root });
-    })
-    .define('branchOrLeaf', 4, (root) => {
-        treeGen.addDetail({ component: 'branch', at: root });
-    })
-    .define('leaf', 1, (root) => {
-        const leaf = root.attach(leafSphere);
-        const scale = Math.random() * 0.5 + 0.5;
-        leaf.setScale(Matrix.fromScaling({ x: scale, y: scale, z: scale }));
-    })
-    .generate({ start: 'branch', depth: 15 });
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
-// Step 3: set up renderer
-///////////////////////////////////////////////////////////////////////////////////////////////////
+    treeGen.addDetail({ component: 'branchOrLeaf', at: node.point('tip') });
+})
+.defineWeighted('branchOrLeaf', 1, (root) => {
+    treeGen.addDetail({ component: 'leaf', at: root });
+})
+.defineWeighted('branchOrLeaf', 4, (root) => {
+    treeGen.addDetail({ component: 'branch', at: root });
+    treeGen.addDetail({ component: 'maybeBranch', at: root });
+    treeGen.addDetail({ component: 'maybeBranch', at: root });
+})
+.define('leaf', (root) => {
+    const leaf = root.attach(leafSphere);
+    leaf.scale(Math.random() * 0.5 + 0.5);
+})
+.defineWeighted('maybeBranch', 1, (root) => {})
+.defineWeighted('maybeBranch', 1, (root) => {
+    treeGen.addDetail({ component: 'branch', at: root });
+});
+const tree = treeGen.generate({ start: 'branch', depth: 25 });
 
 renderer.camera.moveTo({ x: 0, y: 0, z: 8 });
-renderer.camera.lookAt({ x: 2, y: 2, z: -4 });
+renderer.camera.lookAt({ x: 0, y: 2, z: -4 });
 
-renderer.draw([tree], {drawAxes: true, drawArmatureBones: true});
+renderer.draw([tree], {drawAxes: true, drawArmatureBones: false});

--- a/src/frontend/client.ts
+++ b/src/frontend/client.ts
@@ -1,4 +1,5 @@
 import * as calder from 'calder-gl';
+import * as lodash from 'lodash';
 import { Completion } from './Completion';
 const randomSeed = require('random-seed');
 import { range } from 'lodash';
@@ -9,6 +10,10 @@ import 'brace/ext/language_tools';
 
 for (const key in calder) {
     (<any>window)[key] = calder[key];
+}
+
+for (const key in lodash) {
+    (<any>window)[key] = lodash[key];
 }
 
 const logElement = <HTMLDivElement> document.getElementById('log');

--- a/yarn.lock
+++ b/yarn.lock
@@ -819,7 +819,7 @@ cache-base@^1.0.1:
 
 calder-gl@calder-gl/calder#master:
   version "0.0.0"
-  resolved "https://codeload.github.com/calder-gl/calder/tar.gz/b454eaecf42b2bfe5c5e09a412c15258a8f3f6ae"
+  resolved "https://codeload.github.com/calder-gl/calder/tar.gz/a42004e0f87633f28f1b90eacc7e2da52fbaeb0f"
   dependencies:
     "@types/gl-matrix" "^2.4.0"
     "@types/jest" "~22.2.2"
@@ -1905,8 +1905,8 @@ grunt-legacy-util@~1.1.1:
     which "~1.3.0"
 
 grunt-ts@^6.0.0-beta.17:
-  version "6.0.0-beta.19"
-  resolved "https://registry.yarnpkg.com/grunt-ts/-/grunt-ts-6.0.0-beta.19.tgz#387189b027fb2e0fafaea85f06ba8ef8961adf89"
+  version "6.0.0-beta.20"
+  resolved "https://registry.yarnpkg.com/grunt-ts/-/grunt-ts-6.0.0-beta.20.tgz#3d1282b1cdc5fa3ab78fab75670c6cbed05faecb"
   dependencies:
     chokidar "^1.6.1"
     csproj2ts "^1.1.0"
@@ -4102,8 +4102,8 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
 ts-loader@^4.4.1:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-4.4.1.tgz#c93a46eea430ebce1f790dfe438caefb8670d365"
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-4.4.2.tgz#778d4464b24436873c78f7f9e914d88194c2a248"
   dependencies:
     chalk "^2.3.0"
     enhanced-resolve "^4.0.0"
@@ -4378,8 +4378,8 @@ webpack-sources@^1.0.1, webpack-sources@^1.1.0:
     source-map "~0.6.1"
 
 webpack@^4.12.0:
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.12.0.tgz#14758e035ae69747f68dd0edf3c5a572a82bdee9"
+  version "4.12.2"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.12.2.tgz#d2b8418eb40cedcbf2c1f5905d23a99546011ce9"
   dependencies:
     "@webassemblyjs/ast" "1.5.12"
     "@webassemblyjs/helper-module-context" "1.5.12"


### PR DESCRIPTION
- Updates Calder to current master
  - Added instructions to the readme on how to do that reliably. I think we've figured it out now, finally
- Exports all of lodash to the client so you can use things like `range(n)`
- Add tree and snake examples, using most recent Calder methods