### PR TITLE
Set up environment for cost function editing

### DIFF
--- a/samples/generation.js
+++ b/samples/generation.js
@@ -6,10 +6,6 @@ const leafSphere = Shape.sphere(Material.create({ color: leafColor, shininess: 1
 const branchColor = RGBColor.fromRGB(102, 76.5, 76.5);
 const branchShape = Shape.cylinder(Material.create({ color: branchColor, shininess: 1 }));
 
-///////////////////////////////////////////////////////////////////////////////////////////////////
-// Step 2: create armature
-///////////////////////////////////////////////////////////////////////////////////////////////////
-
 const bone = Armature.define((root) => {
     root.createPoint('base', { x: 0, y: 0, z: 0 });
     root.createPoint('mid', { x: 0, y: 0.5, z: 0 });

--- a/samples/generation.js
+++ b/samples/generation.js
@@ -1,0 +1,55 @@
+// Setup leaf
+const leafColor = RGBColor.fromRGB(204, 255, 204);
+const leafSphere = Shape.sphere(Material.create({ color: leafColor, shininess: 100 }));
+
+// Setup branch
+const branchColor = RGBColor.fromRGB(102, 76.5, 76.5);
+const branchShape = Shape.cylinder(Material.create({ color: branchColor, shininess: 1 }));
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Step 2: create armature
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+const bone = Armature.define((root) => {
+    root.createPoint('base', { x: 0, y: 0, z: 0 });
+    root.createPoint('mid', { x: 0, y: 0.5, z: 0 });
+    root.createPoint('tip', { x: 0, y: 1, z: 0 });
+    root.createPoint('handle', { x: 1, y: 0, z: 0 });
+});
+
+generator
+    .define('START', Generator.replaceWith('branch'))
+    .define('branch', (root, instance) => {
+        const node = instance.add(bone());
+        node.point('base').stickTo(root);
+        node.scale(Math.random() * 0.4 + 0.9);
+        node
+            .hold(node.point('tip'))
+            .rotate(Math.random() * 360)
+            .release();
+        node
+            .hold(node.point('handle'))
+            .rotate(Math.random() * 70)
+            .release();
+        node.scale(0.8); // Shrink a bit
+
+        const trunk = instance.add(node.point('mid').attach(branchShape));
+        trunk.scale({ x: 0.2, y: 1, z: 0.2 });
+
+        instance.addDetail({ component: 'branchOrLeaf', at: node.point('tip') });
+    })
+    .defineWeighted('branchOrLeaf', 1, Generator.replaceWith('leaf'))
+    .defineWeighted('branchOrLeaf', 4, (root, instance) => {
+        instance.addDetail({ component: 'branch', at: root });
+        instance.addDetail({ component: 'maybeBranch', at: root });
+        instance.addDetail({ component: 'maybeBranch', at: root });
+    })
+    .define('leaf', (root, instance) => {
+        const leaf = instance.add(root.attach(leafSphere));
+        leaf.scale(Math.random() * 0.5 + 0.5);
+    })
+    .maybe('maybeBranch', (root, instance) => {
+        instance.addDetail({ component: 'branch', at: root });
+    })
+    .wrapUpMany(['branch', 'branchOrLeaf', 'maybeBranch'], Generator.replaceWith('leaf'))
+    .thenComplete(['leaf']);

--- a/src/frontend/costFn.ts
+++ b/src/frontend/costFn.ts
@@ -1,0 +1,47 @@
+import * as calder from 'calder-gl';
+
+// tslint:disable-next-line:import-name
+import Bezier = require('bezier-js');
+
+import { setState, state } from './state';
+
+const scale: [number, number, number] = [0, 0, 100];
+const guidingVectors = [
+    {
+        bezier: new Bezier([
+            { x: 0, y: 0, z: 0 },
+            { x: 0, y: 1, z: 0 },
+            { x: 1, y: 1, z: 1 },
+            { x: 2, y: 2, z: 1 }
+        ]),
+        distanceMultiplier: scale,
+        alignmentMultiplier: 500,
+        alignmentOffset: 0.7
+    },
+    {
+        bezier: new Bezier([
+            { x: 0, y: 1, z: 0 },
+            { x: 0.5, y: 2, z: 1 },
+            { x: 0, y: 3, z: 1 },
+            { x: 0, y: 3, z: 2 }
+        ]),
+        distanceMultiplier: scale,
+        alignmentMultiplier: 500,
+        alignmentOffset: 0.6
+    }
+]
+
+export const addCostFn = () => {
+    const costFn = calder.CostFunction.guidingVectors(guidingVectors);
+
+    setState({ costFn });
+};
+
+export const addCostFunctionViz = () => {
+    if (state.costFn) {
+        const vectorField = state.costFn.generateVectorField();
+        const guidingCurve = state.costFn.generateGuidingCurve();
+
+        setState({ vectorField, guidingCurve });
+    }
+};

--- a/src/frontend/costFn.ts
+++ b/src/frontend/costFn.ts
@@ -38,10 +38,12 @@ export const addCostFn = () => {
 };
 
 export const addCostFunctionViz = () => {
-    if (state.costFn) {
-        const vectorField = state.costFn.generateVectorField();
-        const guidingCurve = state.costFn.generateGuidingCurve();
-
-        setState({ vectorField, guidingCurve });
+    if (!state.costFn) {
+        return;
     }
+
+    const vectorField = state.costFn.generateVectorField();
+    const guidingCurve = state.costFn.generateGuidingCurve();
+
+    setState({ vectorField, guidingCurve });
 };

--- a/src/frontend/editor.ts
+++ b/src/frontend/editor.ts
@@ -1,0 +1,15 @@
+import * as ace from 'brace';
+import 'brace/mode/javascript';
+import 'brace/ext/language_tools';
+
+import { Completion } from './Completion';
+
+const codeElement = <HTMLScriptElement> document.getElementById('code');
+export const editor = ace.edit('source');
+editor.getSession().setValue(codeElement.innerText);
+editor.getSession().setMode('ace/mode/javascript');
+ace.acequire('ace/ext/language_tools').addCompleter(new Completion());
+editor.setOptions({
+    enableBasicAutocompletion: true,
+    enableLiveAutocompletion: true
+});

--- a/src/frontend/generator.ts
+++ b/src/frontend/generator.ts
@@ -1,0 +1,28 @@
+import * as calder from 'calder-gl';
+import { transform } from '@babel/standalone';
+
+import { setState, state } from './state';
+import { editor } from './editor';
+
+export const addGenerator = () => {
+    const source = editor.getSession().getValue();
+
+    if (source === state.source) {
+        return;
+    }
+
+    const { code } = transform(source, { sourceType: 'script' });
+
+    const setup = new Function('generator', code);
+
+    try {
+        const generator = calder.Armature.generator();
+        setup(generator);
+
+        setState({ source, generator });
+    } catch (e) {
+        console.log(e);
+
+        setState({ source, generator: undefined });
+    }
+};

--- a/src/frontend/model.ts
+++ b/src/frontend/model.ts
@@ -1,0 +1,31 @@
+import * as calder from 'calder-gl';
+
+import { setState, state } from './state';
+
+export const addModel = () => {
+    if (state.generatorTask) {
+        // If we were in the middle of generating something else, cancel that task
+        state.generatorTask.cancel();
+    }
+
+    if (state.generator && state.costFn) {
+        state.generatorTask = state.generator.generateSOSMC(
+            {
+                start: 'START',
+                sosmcDepth: 100,
+                samples: (generation: number) => 80 - generation / 100 * 70,
+                heuristicScale: (generation: number) => {
+                    if (generation <= 50) {
+                        return 0.01 - generation / 50 * 0.01;
+                    } else {
+                        return 0;
+                    }
+                },
+                costFn: state.costFn
+            },
+            1 / 30
+        )
+        .then((model: calder.Model) =>
+            setState({ model, generatorTask: undefined }));
+    }
+};

--- a/src/frontend/renderer.ts
+++ b/src/frontend/renderer.ts
@@ -1,0 +1,49 @@
+import * as calder from 'calder-gl';
+
+import { state } from './state';
+
+// Create the renderer
+export const ambientLightColor = calder.RGBColor.fromRGB(90, 90, 90);
+export const renderer: calder.Renderer = new calder.Renderer({
+    width: 400,
+    height: 400,
+    maxLights: 2,
+    ambientLightColor,
+    backgroundColor: calder.RGBColor.fromHex('#FFDDFF')
+});
+
+// Create light sources for the renderer
+const light1: calder.Light = calder.Light.create({
+    position: { x: 10, y: 10, z: 10 },
+    color: calder.RGBColor.fromHex('#FFFFFF'),
+    strength: 200
+});
+
+// Add lights to the renderer
+renderer.addLight(light1);
+
+renderer.camera.lookAt({ x: 0, y: 2, z: 0 });
+
+// Draw the armature
+let angle = 0;
+const draw = () => {
+    angle += 0.001;
+    renderer.camera.moveToWithFixedTarget({
+        x: Math.cos(angle) * 8,
+        y: 2,
+        z: -Math.sin(angle) * 8
+    });
+
+    return {
+        objects: state.model ? [state.model] : [],
+        debugParams: {
+            drawAxes: true,
+            drawArmatureBones: false,
+            drawVectorField: state.vectorField,
+            drawGuidingCurve: state.guidingCurve
+        }
+    };
+};
+
+// Apply the constraints each frame.
+renderer.eachFrame(draw);

--- a/src/frontend/state.ts
+++ b/src/frontend/state.ts
@@ -1,0 +1,19 @@
+import * as calder from 'calder-gl';
+
+export type State = {
+    generator?: calder.Generator;
+    source?: string;
+    model?: calder.Model;
+    costFn?: calder.CostFn;
+    vectorField?: Float32Array;
+    guidingCurve?: [number, number, number][][];
+    generatorTask?: calder.GeneratorTask;
+};
+
+export const state: State = {};
+
+export const setState = (newState: Partial<State>) => {
+    for (const key in newState) {
+        state[key] = newState[key];
+    }
+};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -10,7 +10,7 @@ import * as path from "path";
  */
 export class IndexRoute extends BaseRoute {
     private static defaultSource: string =
-        '' + fs.readFileSync(path.join(__dirname, '../../samples/basic.js'));
+        '' + fs.readFileSync(path.join(__dirname, '../../samples/generation.js'));
 
     /**
      * Create the routes.

--- a/yarn.lock
+++ b/yarn.lock
@@ -113,12 +113,12 @@
     "@types/express" "*"
 
 "@types/node@*":
-  version "10.11.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.11.3.tgz#c055536ac8a5e871701aa01914be5731539d01ee"
+  version "10.11.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.11.4.tgz#e8bd933c3f78795d580ae41d86590bfc1f4f389d"
 
 "@types/node@~8.10.0":
-  version "8.10.30"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.30.tgz#2c82cbed5f79d72280c131d2acffa88fbd8dd353"
+  version "8.10.34"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.34.tgz#a94d9f3767fe45f211e09e49af598bb84822280c"
 
 "@types/range-parser@*":
   version "1.2.2"
@@ -446,7 +446,7 @@ async@^2.6.0:
 
 async@~1.5.2:
   version "1.5.2"
-  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
+  resolved "http://registry.npmjs.org/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
 atob@^2.1.1:
   version "2.1.2"
@@ -824,7 +824,7 @@ cache-base@^1.0.1:
 
 calder-gl@calder-gl/calder#master:
   version "0.0.0"
-  resolved "https://codeload.github.com/calder-gl/calder/tar.gz/5ceedab9a815f7f8f5563e4679160bf24770dfa3"
+  resolved "https://codeload.github.com/calder-gl/calder/tar.gz/37a2bc7ca9fbcc466226b93873f7d0267efb3295"
   dependencies:
     "@types/bezier-js" "^0.0.7"
     "@types/gl-matrix" "^2.4.0"
@@ -1706,7 +1706,7 @@ get-stdin@^4.0.1:
 
 get-stream@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+  resolved "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
@@ -2490,11 +2490,12 @@ map-visit@^1.0.0:
     object-visit "^1.0.0"
 
 md5.js@^1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.4.tgz#e9bdbde94a20a5ac18b04340fc5764d5b09d901d"
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
+    safe-buffer "^5.1.2"
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -3121,14 +3122,15 @@ pstree.remy@^1.1.0:
     ps-tree "^1.1.0"
 
 public-encrypt@^4.0.0:
-  version "4.0.2"
-  resolved "http://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz#46eb9107206bf73489f8b85b69d91334c6610994"
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/public-encrypt/-/public-encrypt-4.0.3.tgz#4fcc9d77a07e48ba7527e7cbe0de33d0701331e0"
   dependencies:
     bn.js "^4.1.0"
     browserify-rsa "^4.0.0"
     create-hash "^1.1.0"
     parse-asn1 "^5.0.0"
     randombytes "^2.0.1"
+    safe-buffer "^5.1.2"
 
 pug-attrs@^2.0.3:
   version "2.0.3"
@@ -3685,8 +3687,8 @@ spdx-correct@^3.0.0:
     spdx-license-ids "^3.0.0"
 
 spdx-exceptions@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz#2c7ae61056c714a5b9b9b2b2af7d311ef5c78fe9"
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz#2ea450aee74f2a89bfb94519c07fcd6f41322977"
 
 spdx-expression-parse@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This splits up the `examples/generation.ts` file from `calder-gl/calder` into pieces that work with the editor.

![screen shot 2018-10-03 at 8 01 40 pm](https://user-images.githubusercontent.com/5315059/46450637-2f999580-c747-11e8-96be-644be014b722.png)

At a high level, here's how everything flows together:
- `costFn.ts` currently owns the cost function params, with no way (yet) to edit them. It will put the same, hard-coded params into a new cost function instance when requested.
- `generator.ts` will make a new `Generator` out of the user's code when requested.
- `model.ts` will use the last existing generator and cost function to kick off a round of SOSMC optimization and store the result when it's done.
- `renderer.ts` will pass whatever model was last made to a renderer every frame.

In the UI, re-running the code will:
1. Make a new cost function instance
2. Make a new generator (this is skipped if the source code is the same as last time)
3. Use both to make a new model

Future work:
- Add UI hooks to edit the cost function
- Integrate obj file importing whenever that's ready on `calder-gl/calder`
