### PR TITLE
Keep cursor position when running code

### DIFF
--- a/src/frontend/editor.ts
+++ b/src/frontend/editor.ts
@@ -15,4 +15,8 @@ editor.setOptions({
     enableLiveAutocompletion: true
 });
 
-onChange('source', () => editor.getSession().setValue(state.source || codeElement.innerText));
+onChange('source', () => {
+    if (editor.getSession().getValue() !== state.source) {
+        editor.getSession().setValue(state.source || codeElement.innerText);
+    }
+});


### PR DESCRIPTION
Fixes https://github.com/calder-gl/playground/issues/26

Every time we updated the source code, we'd save it to the state, and whenever the state updates, we call `.setValue()` on the editor, which resets the cursor position. We now only do `.setValue()` when the source field in the state is different than the editor's current value (basically when saving and loading and not when running code.)