### PR TITLE
Fix minor bugs, add checkboxes for bones and vector field

### DIFF
--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -43,6 +43,7 @@ pre {
 
 pre > code {
     width: 100%;
+    margin: 0;
 }
 
 #source {
@@ -78,14 +79,22 @@ pre > code {
 
 label {
     font-weight: lighter;
-    width: 180px;
+    width: 150px;
     padding: 0.6rem 0;
 }
 
 input {
     flex: 1 1;
-    padding: 5px;
+    padding: 5px !important;
     width: 0;
+}
+
+input[type="checkbox"] {
+    width: auto;
+    flex: 0;
+    margin-bottom: 0;
+    flex: 0;
+    align-self: center;
 }
 
 .group {

--- a/public/views/index.pug
+++ b/public/views/index.pug
@@ -23,6 +23,15 @@ html
           div#toolbar.controls
             button#run Save and Run (Ctrl-R)
             button#export.button-outline Export .obj
+
+          div#rendererControls.controls
+            div.input
+              label(for=vectorField) Show vector field
+              input#vectorField(type='checkbox', checked)
+            div.input
+              label(for=bones) Show bones
+              input#bones(type='checkbox')
+
           pre
             code#log
 
@@ -33,15 +42,15 @@ html
             div.input
               label Distance multiplier
               div.group
-                input#distance1(type=number, disabled)
+                input#distance1(type='number', disabled)
                 span +
-                input#distance2(type=number, disabled)
+                input#distance2(type='number', disabled)
                 span <i>x</i> +
-                input#distance3(type=number, disabled)
+                input#distance3(type='number', disabled)
                 span <i>x</i><sup>2</sup>
             div.input
               label Alignment multiplier
-              input#alignmentMultiplier(type=number, disabled)
+              input#alignmentMultiplier(type='number', disabled)
             div.input
               label Alignment offset
               div.group
@@ -50,7 +59,7 @@ html
                     span -1
                     span.description (lenient)
                   span &le;
-                input#alignmentOffset(type=number, disabled)
+                input#alignmentOffset(type='number', disabled)
                 div.endpoint
                   span &le;
                   div.num

--- a/src/frontend/client.ts
+++ b/src/frontend/client.ts
@@ -62,7 +62,7 @@ runBtn.addEventListener('click', () => {
 });
 
 window.addEventListener('keyup', (event: KeyboardEvent) => {
-    if (event.key == 'r' && event.ctrlKey) {
+    if (event.key == 'r' && (event.ctrlKey || event.altKey)) {
         runBtn.click();
         event.stopPropagation();
         return false;

--- a/src/frontend/renderer.ts
+++ b/src/frontend/renderer.ts
@@ -22,14 +22,19 @@ const light1: calder.Light = calder.Light.create({
 // Add lights to the renderer
 renderer.addLight(light1);
 
+const rendererSettings = {
+    showVectorField: true,
+    showBones: false
+};
+
 // Draw the armature
 const draw = () => {
     return {
         objects: state.model ? [state.model] : [],
         debugParams: {
             drawAxes: true,
-            drawArmatureBones: false,
-            drawVectorField: state.vectorField,
+            drawArmatureBones: rendererSettings.showBones,
+            drawVectorField: rendererSettings.showVectorField ? state.vectorField : undefined,
             drawGuidingCurve: state.guidingCurves && state.guidingCurves.toJS(),
             drawPencilLine: state.pencilLine
         }
@@ -38,3 +43,14 @@ const draw = () => {
 
 // Apply the constraints each frame.
 renderer.eachFrame(draw);
+
+// Set up checkboxes for settings
+const vectorFieldCheckbox = <HTMLInputElement>document.getElementById('vectorField');
+vectorFieldCheckbox.addEventListener('change', () => {
+    rendererSettings.showVectorField = vectorFieldCheckbox.checked;
+});
+
+const bonesCheckbox = <HTMLInputElement>document.getElementById('bones');
+bonesCheckbox.addEventListener('change', () => {
+    rendererSettings.showBones = bonesCheckbox.checked;
+});


### PR DESCRIPTION
Fixes https://github.com/calder-gl/playground/issues/40
Fixes https://github.com/calder-gl/playground/issues/19

Changes here:
- Fixes scroll bar always appearing in the log
- Changes the way mouse movement is handled so that dropped frames don't introduce drift
- Adds checkboxes to toggle the vector field and bones (still TODO: better checkbox CSS, decide if we want bones to match the ones used in the cost function)
- Lets you do alt-R instead of ctrl-R to rerun code so that I have a keyboard shortcut on Windows
- Fixes a mistake in my Pug code that was causing inputs not to have `type='number'` set (I needed to add quotes)
- Reduce zoom speed because on Windows I'm flying into the model in one mouse wheel event

![image](https://user-images.githubusercontent.com/5315059/50112966-9f7bd000-020e-11e9-8f4f-ec5c5531eaec.png)